### PR TITLE
Monitor "replace battery" status

### DIFF
--- a/checks/apcupsd
+++ b/checks/apcupsd
@@ -8,16 +8,16 @@
 # Example output from agent:
 # <<<apcupsd>>>
 # APC       001,043,1061
-# DATE      2012-08-31 12:29:23 +0200  
+# DATE      2012-08-31 12:29:23 +0200
 # HOSTNAME  localhost
 # VERSION   3.14.10 (13 September 2011) debian
 # UPSNAME   localhost
 # CABLE     USB Cable
 # DRIVER    USB UPS Driver
 # UPSMODE   Stand Alone
-# STARTTIME 2012-08-23 16:54:48 +0200  
-# MODEL     Smart-UPS 2200 RM 
-# STATUS    ONLINE 
+# STARTTIME 2012-08-23 16:54:48 +0200
+# MODEL     Smart-UPS 2200 RM
+# STATUS    ONLINE
 # LINEV     228.9 Volts
 # LOADPCT    39.6 Percent Load Capacity
 # BCHARGE   100.0 Percent
@@ -50,10 +50,10 @@
 # NOMOUTV   230 Volts
 # NOMBATTV   48.0 Volts
 # FIRMWARE  665.6.I USB FW:7.3
-# END APC   2012-08-31 12:29:24 +0200  
+# END APC   2012-08-31 12:29:24 +0200
 
 # set default value of variable (user can override in main.mk)
-apcupsd_temp_default_values = (30, 35, 0, 60) 
+apcupsd_temp_default_values = (30, 35, 0, 60)
 apcupsd_bcharge_default_values = (80, 30)
 apcupsd_timeleft_default_values = (20, 10, 0, 60)
 apcupsd_bvoltage_default_values = (20, 15, 0 ,60)
@@ -123,7 +123,7 @@ def check_apcupsd_bcharge(item,params,info):
                 return (1, "WARNIG - Battery charge is %d%%" % charge, perfdata)
             else:
                 return (0, "OK - Battery charge is %d%%" % charge, perfdata)
- 
+
     return (3, "UNKNOWN - not found in agent output")
 
 
@@ -219,6 +219,8 @@ def check_apcupsd_status(item, params, info):
           status = line[1]
           fullstatus = ' '.join(line[1:])
           if status !=  "ONLINE":
+             return (1, "WARNING - Status: %s" % fullstatus)
+          elif fullstatus == "ONLINE REPLACEBATT":
              return (1, "WARNING - Status: %s" % fullstatus)
           else:
               return (0, "OK - Status: %s" % fullstatus)


### PR DESCRIPTION
While using this plugin, I noticed that though the ups status was "ONLINE REPLACEBATT", but the plugin output remained "OK" because it only checks the presence of the word "ONLINE" in the status. I have added just two lines that checks the full status text to see if  the status is "ONLINE
REPLACEBATT" and if so then returns a "Warning" state instead of OK.